### PR TITLE
Support optional destination-specific origin

### DIFF
--- a/MMM-MyCommute.js
+++ b/MMM-MyCommute.js
@@ -285,7 +285,7 @@ Module.register("MMM-MyCommute", {
 	getParams: function(dest) {
 
 		var params = "?";
-		params += "origin=" + encodeURIComponent(this.config.origin);
+		params += "origin=" + encodeURIComponent(dest.origin || this.config.origin);
 		params += "&destination=" + encodeURIComponent(dest.destination);
 		params += "&key=" + this.config.apikey;
 		params += "&language=" + this.config.lang;

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Option                       | Description
 `startTime`                  | The start time of the window during which this destination wil be visible.<br><br>**Type:** `string`<br>Must be in 24-hour time format. Defaults to `00:00` (i.e.: midnight)
 `endTime`                    | The end time of the window during which this destination wil be visible.<br><br>**Type:** `string`<br>Must be in 24-hour time format. Defaults to `23:59` (i.e.: one minute before midnight).
 `hideDays`                   | A list of numbers representing days of the week to hide the destination.<br><br>**Type:** `array`<br>Valid numbers are 0 through 6, 0 = Sunday, 6 = Saturday.<br>e.g.: `[0,6]` hides the destination on weekends.
+`origin`                     | Optionally overide the global origin for a single destination.
 
 Here is an example of an entry in `config.js`
 


### PR DESCRIPTION
Allow people to override the global origin for a single destination.

This is quite useful for people like me who need to drive to a train station.